### PR TITLE
Remove explicit chroot support

### DIFF
--- a/lib/kazoo/cli.rb
+++ b/lib/kazoo/cli.rb
@@ -3,8 +3,7 @@ require 'thor'
 
 module Kazoo
   class CLI < Thor
-    class_option :zookeeper, :type => :string, :default => ENV['ZOOKEEPER_PEERS']
-    class_option :chroot, :type => :string, :default => ""
+    class_option :zookeeper, :type => :string, :default => ENV['ZOOKEEPER']
 
     desc "cluster", "Describes the Kafka cluster as registered in Zookeeper"
     def cluster
@@ -73,7 +72,7 @@ module Kazoo
     end
 
     def kafka_cluster
-      @kafka_cluster ||= Kazoo::Cluster.new(options[:zookeeper], chroot: options[:chroot])
+      @kafka_cluster ||= Kazoo::Cluster.new(options[:zookeeper])
     end
   end
 end

--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -1,10 +1,10 @@
 module Kazoo
   class Cluster
 
-    attr_reader :zookeeper, :chroot
+    attr_reader :zookeeper
 
-    def initialize(zookeeper, chroot: "")
-      @zookeeper, @chroot = zookeeper, chroot
+    def initialize(zookeeper)
+      @zookeeper = zookeeper
       @zk_mutex, @brokers_mutex, @topics_mutex = Mutex.new, Mutex.new, Mutex.new
     end
 
@@ -17,11 +17,11 @@ module Kazoo
     def brokers
       @brokers_mutex.synchronize do
         @brokers ||= begin
-          brokers = zk.get_children(path: node_with_chroot("/brokers/ids"))
+          brokers = zk.get_children(path: "/brokers/ids")
           result, threads, mutex = {}, ThreadGroup.new, Mutex.new
           brokers.fetch(:children).map do |id|
             t = Thread.new do
-              broker_info = zk.get(path: node_with_chroot("/brokers/ids/#{id}"))
+              broker_info = zk.get(path: "/brokers/ids/#{id}")
               broker = Kazoo::Broker.from_json(self, id, JSON.parse(broker_info.fetch(:data)))
               mutex.synchronize { result[id.to_i] = broker }
             end
@@ -36,11 +36,11 @@ module Kazoo
     def topics
       @topics_mutex.synchronize do
         @topics ||= begin
-          topics = zk.get_children(path: node_with_chroot("/brokers/topics"))
+          topics = zk.get_children(path: "/brokers/topics")
           result, threads, mutex = {}, ThreadGroup.new, Mutex.new
           topics.fetch(:children).each do |name|
             t = Thread.new do
-              topic_info = zk.get(path: node_with_chroot("/brokers/topics/#{name}"))
+              topic_info = zk.get(path: "/brokers/topics/#{name}")
               topic = Kazoo::Topic.from_json(self, name, JSON.parse(topic_info.fetch(:data)))
               mutex.synchronize { result[name] = topic }
             end
@@ -64,8 +64,8 @@ module Kazoo
       partitions.any?(&:under_replicated?)
     end
 
-    def node_with_chroot(path)
-      "#{@chroot}#{path}"
+    def close
+      zk.close
     end
   end
 end

--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -36,7 +36,7 @@ module Kazoo
     protected
 
     def refresh_state
-      state_json = cluster.zk.get(path: cluster.node_with_chroot("/brokers/topics/#{topic.name}/partitions/#{id}/state"))
+      state_json = cluster.zk.get(path: "/brokers/topics/#{topic.name}/partitions/#{id}/state")
       set_state(JSON.parse(state_json.fetch(:data)))
     end
 

--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -33,6 +33,20 @@ module Kazoo
       isr.length < replication_factor
     end
 
+    def inspect
+      "#<Kazoo::Partition #{topic.name}/#{id}>"
+    end
+
+    def eql?(other)
+      other.kind_of?(Kazoo::Partition) && topic == other.topic && id == other.id
+    end
+
+    alias_method :==, :eql?
+
+    def hash
+      [topic, id].hash
+    end
+
     protected
 
     def refresh_state

--- a/lib/kazoo/topic.rb
+++ b/lib/kazoo/topic.rb
@@ -28,5 +28,19 @@ module Kazoo
     def under_replicated?
       partitions.any?(:under_replicated?)
     end
+
+    def inspect
+      "#<Kazoo::Topic #{name}>"
+    end
+
+    def eql?(other)
+      other.kind_of?(Kazoo::Topic) && cluster == other.cluster && name == other.name
+    end
+
+    alias_method :==, :eql?
+
+    def hash
+      [cluster, name].hash
+    end
   end
 end


### PR DESCRIPTION
The underlying ZK library already supports chroots by simply adding it to the connection string, e.g. `zk1:2181,zk2:2181,zk3:2181/chroot`

Also, implements some methods that makes it easier to compare topics and partitions, and allow using them as hash keys.

@andremedeiros 