### PR TITLE
Properly handle unexpected zookeeper result codes

### DIFF
--- a/lib/kazoo.rb
+++ b/lib/kazoo.rb
@@ -3,6 +3,9 @@ require 'json'
 require 'thread'
 
 module Kazoo
+  Error = Class.new(StandardError)
+
+  NoClusterRegistered = Class.new(Kazoo::Error)
 end
 
 require 'kazoo/cluster'

--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -18,10 +18,17 @@ module Kazoo
       @brokers_mutex.synchronize do
         @brokers ||= begin
           brokers = zk.get_children(path: "/brokers/ids")
+
+          if brokers.fetch(:rc) != Zookeeper::Constants::ZOK
+            raise NoClusterRegistered, "No Kafka cluster registered on this Zookeeper location."
+          end
+
           result, threads, mutex = {}, ThreadGroup.new, Mutex.new
           brokers.fetch(:children).map do |id|
             t = Thread.new do
               broker_info = zk.get(path: "/brokers/ids/#{id}")
+              raise Kazoo::Error, "Failed to retrieve broker info. Error code: #{broker_info.fetch(:rc)}" unless broker_info.fetch(:rc) == Zookeeper::Constants::ZOK
+
               broker = Kazoo::Broker.from_json(self, id, JSON.parse(broker_info.fetch(:data)))
               mutex.synchronize { result[id.to_i] = broker }
             end
@@ -37,10 +44,14 @@ module Kazoo
       @topics_mutex.synchronize do
         @topics ||= begin
           topics = zk.get_children(path: "/brokers/topics")
+          raise Kazoo::Error, "Failed to list topics. Error code: #{topics.fetch(:rc)}" unless topics.fetch(:rc) == Zookeeper::Constants::ZOK
+
           result, threads, mutex = {}, ThreadGroup.new, Mutex.new
           topics.fetch(:children).each do |name|
             t = Thread.new do
               topic_info = zk.get(path: "/brokers/topics/#{name}")
+              raise Kazoo::Error, "Failed to get topic info. Error code: #{topic_info.fetch(:rc)}" unless topic_info.fetch(:rc) == Zookeeper::Constants::ZOK
+
               topic = Kazoo::Topic.from_json(self, name, JSON.parse(topic_info.fetch(:data)))
               mutex.synchronize { result[name] = topic }
             end

--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -51,6 +51,8 @@ module Kazoo
 
     def refresh_state
       state_json = cluster.zk.get(path: "/brokers/topics/#{topic.name}/partitions/#{id}/state")
+      raise Kazoo::Error, "Failed to get partition state. Error code: #{state_json.fetch(:rc)}" unless state_json.fetch(:rc) == Zookeeper::Constants::ZOK
+
       set_state(JSON.parse(state_json.fetch(:data)))
     end
 

--- a/test/partition_test.rb
+++ b/test/partition_test.rb
@@ -17,7 +17,7 @@ class PartitionTest < Minitest::Test
     partition.unstub(:isr)
 
     json_payload = '{"controller_epoch":157,"leader":1,"version":1,"leader_epoch":8,"isr":[3,2,1]}'
-    @cluster.zk.expects(:get).with(path: "/brokers/topics/test.1/partitions/0/state").returns(data: json_payload)
+    @cluster.zk.expects(:get).with(path: "/brokers/topics/test.1/partitions/0/state").returns(data: json_payload, rc: 0)
 
     assert_equal 1, partition.leader.id
     assert_equal [3,2,1], partition.isr.map(&:id)


### PR DESCRIPTION
The ZK library doesn't raise an exception when a node does not exist; you have to check the response code instead.

@andremedeiros - this should fix the exception you were seeing