### PR TITLE
Add create topic and delete topic methods

### DIFF
--- a/lib/kazoo.rb
+++ b/lib/kazoo.rb
@@ -7,6 +7,7 @@ require 'securerandom'
 module Kazoo
   Error = Class.new(StandardError)
 
+  ValidationError = Class.new(Kazoo::Error)
   NoClusterRegistered = Class.new(Kazoo::Error)
   ConsumerInstanceRegistrationFailed = Class.new(Kazoo::Error)
   PartitionAlreadyClaimed = Class.new(Kazoo::Error)

--- a/lib/kazoo/cli.rb
+++ b/lib/kazoo/cli.rb
@@ -3,7 +3,7 @@ require 'thor'
 
 module Kazoo
   class CLI < Thor
-    class_option :zookeeper, :type => :string, :default => ENV['ZOOKEEPER']
+    class_option :zookeeper, type: :string, default: ENV['ZOOKEEPER']
 
     desc "cluster", "Describes the Kafka cluster as registered in Zookeeper"
     def cluster
@@ -23,7 +23,25 @@ module Kazoo
       end
     end
 
-    option :topic, :type => :string
+    desc "create_topic", "Creates a new topic"
+    option :name, type: :string, required: true
+    option :partitions, type: :numeric, required: true
+    option :replication_factor, type: :numeric, required: true
+    def create_topic
+      validate_class_options!
+
+      kafka_cluster.create_topic(options[:name], partitions: options[:partitions], replication_factor: options[:replication_factor])
+    end
+
+    desc "delete_topic", "Removes a topic"
+    option :name, type: :string, required: true
+    def delete_topic
+      validate_class_options!
+
+      kafka_cluster.topics.fetch(options[:name]).destroy
+    end
+
+    option :topic, type: :string
     desc "partitions", "Lists partitions"
     def partitions
       validate_class_options!
@@ -39,7 +57,7 @@ module Kazoo
       end
     end
 
-    option :replicas, :type => :numeric, :default => 1
+    option :replicas, type: :numeric, default: 1
     desc "critical <broker>", "Determine whether a broker is critical"
     def critical(broker_name)
       validate_class_options!

--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -71,23 +71,10 @@ module Kazoo
     end
 
     def create_topic(name, partitions: nil, replication_factor: nil)
-      raise ArgumentError, "partitions must be set to a positive integer" if partitions.nil?
-      raise ArgumentError, "replication_factor must be set to a positive integer" if replication_factor.nil?
+      raise ArgumentError, "partitions must be a positive integer" if Integer(partitions) <= 0
+      raise ArgumentError, "replication_factor must be a positive integer" if Integer(replication_factor) <= 0
 
-      brokers = self.brokers.values
-      partition_assignment = {}
-      partitions.times do |partition|
-        partition_assignment[partition.to_s] = []
-        replication_factor.times do |replica|
-          index = (partition + replica) % brokers.length
-          partition_assignment[partition.to_s] << brokers[index].id
-        end
-      end
-
-      json = { "version" => 1, "partitions" => partition_assignment}
-      topic = Kazoo::Topic.from_json(self, name, json)
-      topic.create
-      topic
+      Kazoo::Topic.create(self, name, partitions: Integer(partitions), replication_factor: Integer(replication_factor))
     end
 
     def partitions

--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -33,6 +33,19 @@ module Kazoo
       isr.length < replication_factor
     end
 
+    def validate
+      raise Kazoo::ValidationError, "No replicas defined for #{topic.name}/#{id}" if replicas.length == 0
+      raise Kazoo::ValidationError, "The replicas of #{topic.name}/#{id} should be assigned to different brokers" if replicas.length > replicas.uniq.length
+
+      true
+    end
+
+    def valid?
+      validate
+    rescue Kazoo::ValidationError
+      false
+    end
+
     def inspect
       "#<Kazoo::Partition #{topic.name}/#{id}>"
     end

--- a/lib/kazoo/topic.rb
+++ b/lib/kazoo/topic.rb
@@ -1,11 +1,13 @@
 module Kazoo
   class Topic
+    VALID_TOPIC_NAME = %r{\A[a-zA-Z0-9\\._\\-]+\z}
 
     attr_reader :cluster, :name
     attr_accessor :partitions
 
-    def initialize(cluster, name, partitions: nil)
-      @cluster, @name, @partitions = cluster, name, partitions
+    def initialize(cluster, name)
+      @cluster, @name = cluster, name
+      @partitions = []
     end
 
     def self.from_json(cluster, name, json)
@@ -48,10 +50,28 @@ module Kazoo
       stat.fetch(:stat).exists?
     end
 
+    def validate
+      raise Kazoo::ValidationError, "#{name} is not a valid topic name" if VALID_TOPIC_NAME !~ name
+      raise Kazoo::ValidationError, "#{name} is too long" if name.length > 255
+      raise Kazoo::ValidationError, "The topic has no partitions defined" if partitions.length == 0
+      partitions.each(&:validate)
+
+      true
+    end
+
+    def valid?
+      validate
+    rescue Kazoo::ValidationError
+      false
+    end
+
     def create
+      raise Kazoo::Error, "The topic #{name} already exists!" if exist?
+      validate
+
       result = cluster.zk.create(
         path: "/brokers/topics/#{name}",
-        data: JSON.dump(version: 1, partitions: partition_assignment)
+        data: JSON.dump(version: 1, partitions: partitions_as_json)
       )
 
       if result.fetch(:rc) != Zookeeper::Constants::ZOK
@@ -68,9 +88,31 @@ module Kazoo
       end
     end
 
-    private
+    def self.create(cluster, name, partitions: nil, replication_factor: nil)
+      topic = new(cluster, name)
+      topic.send(:sequentially_assign_partitions, partitions, replication_factor)
+      topic.create
+      topic
+    end
 
-    def partition_assignment
+    protected
+
+    def sequentially_assign_partitions(partition_count, replication_factor, brokers: nil)
+      brokers = cluster.brokers.values if brokers.nil?
+      raise ArgumentError, "replication_factor should be smaller or equal to the number of brokers" if replication_factor > brokers.length
+
+      # Sequentially assign replicas to brokers. There might be a better way.
+      @partitions = 0.upto(partition_count - 1).map do |partition_index|
+        replicas = 0.upto(replication_factor - 1).map do |replica_index|
+          broker_index = (partition_index + replica_index) % brokers.length
+          brokers[broker_index]
+        end
+
+        self.partition(partition_index, replicas: replicas)
+      end
+    end
+
+    def partitions_as_json
       partitions.inject({}) do |hash, partition|
         hash[partition.id] = partition.replicas.map(&:id)
         hash

--- a/lib/kazoo/topic.rb
+++ b/lib/kazoo/topic.rb
@@ -1,6 +1,7 @@
 module Kazoo
   class Topic
-    VALID_TOPIC_NAME = %r{\A[a-zA-Z0-9\\._\\-]+\z}
+    VALID_TOPIC_NAMES = %r{\A[a-zA-Z0-9\\._\\-]+\z}
+    BLACKLISTED_TOPIC_NAMES = %r{\A\.\.?\z}
 
     attr_reader :cluster, :name
     attr_accessor :partitions
@@ -51,7 +52,8 @@ module Kazoo
     end
 
     def validate
-      raise Kazoo::ValidationError, "#{name} is not a valid topic name" if VALID_TOPIC_NAME !~ name
+      raise Kazoo::ValidationError, "#{name} is not a valid topic name" if VALID_TOPIC_NAMES !~ name
+      raise Kazoo::ValidationError, "#{name} is not a valid topic name" if BLACKLISTED_TOPIC_NAMES =~ name
       raise Kazoo::ValidationError, "#{name} is too long" if name.length > 255
       raise Kazoo::ValidationError, "The topic has no partitions defined" if partitions.length == 0
       partitions.each(&:validate)

--- a/test/partition_test.rb
+++ b/test/partition_test.rb
@@ -37,4 +37,10 @@ class PartitionTest < Minitest::Test
     assert p1 != Kazoo::Partition.new(@cluster.topics['test.4'], 0)
     assert_equal p1.hash, p2.hash
   end
+
+  def test_validate
+    partition = Kazoo::Partition.new(@cluster.topics['test.1'], 1, replicas: [@cluster.brokers[1], @cluster.brokers[1]])
+    refute partition.valid?
+    assert_raises(Kazoo::ValidationError) { partition.validate }
+  end
 end

--- a/test/topic_test.rb
+++ b/test/topic_test.rb
@@ -51,8 +51,39 @@ class TopicTest < Minitest::Test
     assert_equal t1.hash, t2.hash
   end
 
-  def test_partition_assignment
-    assignment = @cluster.topics['test.1'].send(:partition_assignment)
+  def test_validate
+    t = Kazoo::Topic.new(@cluster, "normal")
+    t.partitions = [t.partition(0, replicas: [@cluster.brokers[1]])]
+    assert t.valid?
+
+    t = Kazoo::Topic.new(@cluster, "invalid/character")
+    t.partitions = [t.partition(0, replicas: [@cluster.brokers[1]])]
+    refute t.valid?
+
+    t = Kazoo::Topic.new(@cluster, "l#{'o' * 253}ng")
+    t.partitions = [t.partition(0, replicas: [@cluster.brokers[1]])]
+    refute t.valid?
+
+    t = Kazoo::Topic.new(@cluster, "normal")
+    t.partitions = [t.partition(0, replicas: [])]
+    refute t.valid?
+  end
+
+  def test_sequentially_assign_partitions
+    topic = Kazoo::Topic.new(@cluster, 'test.new')
+
+    assert_raises(ArgumentError) { topic.send(:sequentially_assign_partitions, 4, 100) }
+
+    topic.send(:sequentially_assign_partitions, 4, 3)
+
+    assert_equal 4, topic.partitions.length
+    assert_equal 3, topic.replication_factor
+    assert topic.partitions.all? { |p| p.replicas.length == 3 }
+    assert topic.valid?
+  end
+
+  def test_partitions_as_json
+    assignment = @cluster.topics['test.1'].send(:partitions_as_json)
     assert_equal 1, assignment.length
     assert_equal [1,2], assignment[0]
   end

--- a/test/topic_test.rb
+++ b/test/topic_test.rb
@@ -50,4 +50,10 @@ class TopicTest < Minitest::Test
     assert t1 != Kazoo::Topic.new(@cluster, 'test.2')
     assert_equal t1.hash, t2.hash
   end
+
+  def test_partition_assignment
+    assignment = @cluster.topics['test.1'].send(:partition_assignment)
+    assert_equal 1, assignment.length
+    assert_equal [1,2], assignment[0]
+  end
 end

--- a/test/topic_test.rb
+++ b/test/topic_test.rb
@@ -60,6 +60,10 @@ class TopicTest < Minitest::Test
     t.partitions = [t.partition(0, replicas: [@cluster.brokers[1]])]
     refute t.valid?
 
+    t = Kazoo::Topic.new(@cluster, "..")
+    t.partitions = [t.partition(0, replicas: [@cluster.brokers[1]])]
+    refute t.valid?
+
     t = Kazoo::Topic.new(@cluster, "l#{'o' * 253}ng")
     t.partitions = [t.partition(0, replicas: [@cluster.brokers[1]])]
     refute t.valid?


### PR DESCRIPTION
I reverse-engineered the way topics are created and deleted using Zookeeper, based on the JVM implementation. The primary reason I want this, is that it makes writing tests for anything Kafka related a lot easier, because you can create a topic, know its state for testing purposes, and destroy it afterwards. However, we may be able to use this instead of the JVM command line tool which is cumbersome to use.

- The assignment of replicas to brokers is very basic, but does the trick.
- I also added two commands to the CLI tool to create and destroy a topic.
- What may be missing is a wait for the topics to be created/deleted, but that should be possible with setting some zookeeper watches. This is useful for waiting to continue your test, and avoid flakiness.
- I also want to add this to the go version of this library.

@andremedeiros @eapache 