### PR TITLE
Add Subscription concept

### DIFF
--- a/lib/kazoo.rb
+++ b/lib/kazoo.rb
@@ -3,6 +3,8 @@ require 'json'
 require 'thread'
 require 'socket'
 require 'securerandom'
+require 'bigdecimal'
+require 'time'
 
 module Kazoo
   Error = Class.new(StandardError)
@@ -14,6 +16,9 @@ module Kazoo
   ConsumerInstanceRegistrationFailed = Class.new(Kazoo::Error)
   PartitionAlreadyClaimed = Class.new(Kazoo::Error)
   ReleasePartitionFailure = Class.new(Kazoo::Error)
+  InvalidSubscription = Class.new(Kazoo::Error)
+  InconsistentSubscriptions = Class.new(Kazoo::Error)
+  NoRunningInstances = Class.new(Kazoo::Error)
 
   def self.connect(zookeeper)
     Kazoo::Cluster.new(zookeeper)
@@ -24,5 +29,6 @@ require 'kazoo/cluster'
 require 'kazoo/broker'
 require 'kazoo/topic'
 require 'kazoo/partition'
+require 'kazoo/subscription'
 require 'kazoo/consumergroup'
 require 'kazoo/version'

--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -23,18 +23,18 @@ module Kazoo
             raise NoClusterRegistered, "No Kafka cluster registered on this Zookeeper location."
           end
 
-          result, threads, mutex = {}, ThreadGroup.new, Mutex.new
-          brokers.fetch(:children).map do |id|
-            t = Thread.new do
+          result, mutex = {}, Mutex.new
+          threads = brokers.fetch(:children).map do |id|
+            Thread.new do
+              Thread.abort_on_exception = true
               broker_info = zk.get(path: "/brokers/ids/#{id}")
               raise Kazoo::Error, "Failed to retrieve broker info. Error code: #{broker_info.fetch(:rc)}" unless broker_info.fetch(:rc) == Zookeeper::Constants::ZOK
 
               broker = Kazoo::Broker.from_json(self, id, JSON.parse(broker_info.fetch(:data)))
               mutex.synchronize { result[id.to_i] = broker }
             end
-            threads.add(t)
           end
-          threads.list.each(&:join)
+          threads.each(&:join)
           result
         end
       end
@@ -57,18 +57,18 @@ module Kazoo
           topics = zk.get_children(path: "/brokers/topics")
           raise Kazoo::Error, "Failed to list topics. Error code: #{topics.fetch(:rc)}" unless topics.fetch(:rc) == Zookeeper::Constants::ZOK
 
-          result, threads, mutex = {}, ThreadGroup.new, Mutex.new
-          topics.fetch(:children).each do |name|
-            t = Thread.new do
+          result, mutex = {}, Mutex.new
+          threads = topics.fetch(:children).map do |name|
+            Thread.new do
+              Thread.abort_on_exception = true
               topic_info = zk.get(path: "/brokers/topics/#{name}")
               raise Kazoo::Error, "Failed to get topic info. Error code: #{topic_info.fetch(:rc)}" unless topic_info.fetch(:rc) == Zookeeper::Constants::ZOK
 
               topic = Kazoo::Topic.from_json(self, name, JSON.parse(topic_info.fetch(:data)))
               mutex.synchronize { result[name] = topic }
             end
-            threads.add(t)
           end
-          threads.list.each(&:join)
+          threads.each(&:join)
           result
         end
       end

--- a/lib/kazoo/subscription.rb
+++ b/lib/kazoo/subscription.rb
@@ -1,0 +1,182 @@
+module Kazoo
+  class Subscription
+    attr_reader :timestamp, :version
+
+    def self.everything
+      create(/.*/)
+    end
+
+    def self.create(subscription, pattern: :white_list, timestamp: Time.now)
+      case subscription
+      when Kazoo::Subscription
+        subscription
+      when String, Symbol, Kazoo::Topic, Array
+        topic_names = Array(subscription).map { |t| topic_name(t) }
+        Kazoo::StaticSubscription.new(topic_names, timestamp: timestamp)
+      when Regexp
+        Kazoo::PatternSubscription.new(subscription, pattern: pattern, timestamp: timestamp)
+      else
+        raise ArgumentError, "Don't know how to create a subscription from #{subscription.inspect}"
+      end
+    end
+
+    def self.topic_name(topic)
+      case topic
+        when String, Symbol; topic.to_s
+        when Kazoo::Topic;   topic.name
+        else raise ArgumentError, "Cannot get topic name from #{topic.inspect}"
+      end
+    end
+
+    def self.from_json(json_payload)
+      json = JSON.parse(json_payload)
+      version, timestamp = json.fetch('version'), json.fetch('timestamp')
+      raise Kazoo::InvalidSubscription, "Only version 1 subscriptions are supported, found version #{version}!" unless version == 1
+
+      time = Time.at(BigDecimal.new(timestamp) / BigDecimal.new(1000))
+
+      pattern, subscription = json.fetch('pattern'), json.fetch('subscription')
+      raise Kazoo::InvalidSubscription, "Only subscriptions with a single stream are supported" unless subscription.values.all? { |streams| streams == 1 }
+
+      case pattern
+      when 'static'
+        topic_names = subscription.keys
+        Kazoo::StaticSubscription.new(topic_names, version: version, timestamp: time)
+
+      when 'white_list', 'black_list'
+        raise Kazoo::InvalidSubscription, "Only pattern subscriptions with a single expression are supported" unless subscription.keys.length == 1
+        regexp = Regexp.new(subscription.keys.first.tr(',', '|'))
+        Kazoo::PatternSubscription.new(regexp, pattern: pattern.to_sym, version: version, timestamp: time)
+
+      else
+        raise Kazoo::InvalidSubscription, "Unrecognized subscription pattern #{pattern.inspect}"
+      end
+
+    rescue JSON::ParserError, KeyError => e
+      raise Kazoo::InvalidSubscription.new(e.message)
+    end
+
+    def initialize(timestamp: Time.now, version: 1)
+      @timestamp, @version = timestamp, version
+    end
+
+    def watch_partitions(kazoo)
+      raise NotImplementedError
+    end
+
+    def topics(kazoo)
+      kazoo.topics.values.select { |topic| has_topic?(topic) }
+    end
+
+    def has_topic?(topic)
+      raise NotImplementedError
+    end
+
+    def as_json(options = {})
+      {
+        version:      version,
+        pattern:      pattern,
+        timestamp:    msec_timestamp,
+        subscription: subscription,
+      }
+    end
+
+    def to_json(options = {})
+      JSON.dump(as_json(options))
+    end
+
+    def eql?(other)
+      other.kind_of?(Kazoo::Subscription) && other.pattern == pattern && other.subscription == subscription
+    end
+
+    alias_method :==, :eql?
+
+    def hash
+      [pattern, subscription].hash
+    end
+
+    def inspect
+      "#<#{self.class.name} pattern=#{pattern} subscription=#{subscription.inspect}>"
+    end
+
+    protected
+
+    def subscription
+      raise NotImplementedError
+    end
+
+    def pattern
+      raise NotImplementedError
+    end
+
+    private
+
+    def msec_timestamp
+      (timestamp.to_i * 1000) + (timestamp.nsec / 1_000_000)
+    end
+  end
+
+  class StaticSubscription < Kazoo::Subscription
+    attr_reader :topic_names
+
+    def initialize(topic_names, **kwargs)
+      super(**kwargs)
+      @topic_names = topic_names
+    end
+
+    def watch_partitions(kazoo)
+      # TODO
+    end
+
+    def has_topic?(topic)
+      topic_names.include?(topic.name)
+    end
+
+    protected
+
+    def pattern
+      :static
+    end
+
+    def subscription
+      topic_names.inject({}) { |hash, topic_name| hash[topic_name] = 1; hash }
+    end
+  end
+
+  class PatternSubscription < Kazoo::Subscription
+    PATTERN_TYPES = [:black_list, :white_list].freeze
+
+    attr_reader :pattern, :regexp
+
+    def initialize(regexp, pattern: :white_list, **kwargs)
+      super(**kwargs)
+      raise ArgumentError, "#{pattern.inspect} is not a vaid pattern type" unless PATTERN_TYPES.include?(pattern)
+      @regexp, @pattern = regexp, pattern
+    end
+
+    def watch_partitions(kazoo)
+      # TODO
+    end
+
+    def white_list?
+      pattern == :white_list
+    end
+
+    def black_list?
+      pattern == :black_list
+    end
+
+    def has_topic?(topic)
+      case pattern
+        when :white_list; topic.name =~ regexp
+        when :black_list; topic.name !~ regexp
+      end
+    end
+
+    protected
+
+    def subscription
+      { regexp.inspect[1..-2] => 1 }
+    end
+  end
+end

--- a/test/functional/functional_consumergroup_test.rb
+++ b/test/functional/functional_consumergroup_test.rb
@@ -7,11 +7,18 @@ class FunctionalConsumergroupTest < Minitest::Test
     @cg = Kazoo::Consumergroup.new(@cluster, 'test.kazoo')
     @cg.create
 
-    @topic = @cluster.create_topic("test.4", partitions: 4, replication_factor: 1)
+    @topic1 = @cluster.topic('test.1')
+    @topic1.destroy if @topic1.exists?
+    @topic1 = @cluster.create_topic('test.1', partitions: 1, replication_factor: 1)
+
+    @topic4 = @cluster.topic('test.4')
+    @topic4.destroy if @topic4.exists?
+    @topic4 = @cluster.create_topic('test.4', partitions: 4, replication_factor: 1)
   end
 
   def teardown
-    @topic.destroy
+    @topic1.destroy if @topic1.exists?
+    @topic4.destroy if @topic4.exists?
 
     cg = Kazoo::Consumergroup.new(@cluster, 'test.kazoo')
     cg.destroy if cg.exists?
@@ -30,32 +37,19 @@ class FunctionalConsumergroupTest < Minitest::Test
     refute cg.exists?
   end
 
-  def test_retrieve_and_commit_offsets
-    topic = Kazoo::Topic.new(@cluster, 'test.1')
-    partition = Kazoo::Partition.new(topic, 0)
-
-    assert_nil @cg.retrieve_offset(partition)
-
-    @cg.commit_offset(partition, 1234)
-
-    assert_equal 1234 + 1, @cg.retrieve_offset(partition)
-
-    @cg.reset_all_offsets
-    assert_nil @cg.retrieve_offset(partition)
-  end
-
   def test_unclaimed_partitions
-    partition40 = @topic.partition(0)
-    partition41 = @topic.partition(1)
-    partition42 = @topic.partition(2)
-    partition43 = @topic.partition(3)
+    partition40 = @topic4.partition(0)
+    partition41 = @topic4.partition(1)
+    partition42 = @topic4.partition(2)
+    partition43 = @topic4.partition(3)
 
     refute @cg.active?
 
-    instance1 = @cg.instantiate
-    instance1.register([@topic])
-    instance2 = @cg.instantiate
-    instance2.register([@topic])
+    subscription = Kazoo::Subscription.create(@topic4)
+    instance1 = @cg.instantiate(subscription: subscription)
+    instance1.register
+    instance2 = @cg.instantiate(subscription: subscription)
+    instance2.register
 
     assert @cg.active?
 
@@ -63,50 +57,15 @@ class FunctionalConsumergroupTest < Minitest::Test
     instance2.claim_partition(partition41)
 
     assert_equal 2, @cg.partition_claims.length
-    assert_equal [@topic], @cg.topics
-    assert_equal @topic.partitions, @cg.partitions
+    assert_equal [@topic4], @cg.topics
+    assert_equal @topic4.partitions, @cg.partitions
 
     assert_equal Set[partition42, partition43], Set.new(@cg.unclaimed_partitions)
   end
 
-  def test_retrieve_all_offsets
-    topic1 = Kazoo::Topic.new(@cluster, 'test.1')
-    partition10 = Kazoo::Partition.new(topic1, 0)
-
-    topic4 = Kazoo::Topic.new(@cluster, 'test.4')
-    partition40 = Kazoo::Partition.new(topic4, 0)
-    partition41 = Kazoo::Partition.new(topic4, 1)
-    partition42 = Kazoo::Partition.new(topic4, 2)
-    partition43 = Kazoo::Partition.new(topic4, 3)
-
-    assert_equal Hash.new, @cg.retrieve_all_offsets
-
-    @cg.commit_offset(partition10, 10)
-    @cg.commit_offset(partition40, 40)
-    @cg.commit_offset(partition41, 41)
-    @cg.commit_offset(partition42, 42)
-    @cg.commit_offset(partition43, 43)
-
-    offsets = @cg.retrieve_all_offsets
-
-    assert_equal 5, offsets.length
-    assert_equal 11, offsets[partition10]
-    assert_equal 41, offsets[partition40]
-    assert_equal 42, offsets[partition41]
-    assert_equal 43, offsets[partition42]
-    assert_equal 44, offsets[partition43]
-
-    @cg.reset_all_offsets
-    assert_equal Hash.new, @cg.retrieve_all_offsets
-  end
-
   def test_watch_instances
-    topic = Kazoo::Topic.new(@cluster, 'test.1')
-
-    instance1 = @cg.instantiate
-    instance1.register([topic])
-    instance2 = @cg.instantiate
-    instance2.register([topic])
+    instance1 = @cg.instantiate(subscription: @topic1).register
+    instance2 = @cg.instantiate(subscription: @topic1).register
 
     t = Thread.current
     instances, cb = @cg.watch_instances { t.run if t.status == 'sleep' }
@@ -118,5 +77,98 @@ class FunctionalConsumergroupTest < Minitest::Test
 
     assert assert_equal Set[instance1], Set.new(@cg.instances)
     instance1.deregister
+  end
+
+  def test_cleanup_topics
+    deleted_topic = @cluster.topic('non_existing')
+    deleted_topic.destroy if deleted_topic.exists?
+    deleted_topic = @cluster.create_topic('non_existing', partitions: 1, replication_factor: 1)
+
+    subscription = Kazoo::Subscription.create([@topic4, deleted_topic])
+    @cg.instantiate(subscription: subscription).register
+
+    deleted_topic.destroy
+
+    assert_equal Set[@topic4, deleted_topic], Set.new(@cg.topics)
+
+    @cg.cleanup_topics(Kazoo::Subscription.everything)
+    assert_equal Set[@topic4], Set.new(@cg.topics)
+
+    @cg.cleanup_topics(Kazoo::Subscription.create([]))
+    assert_equal [], @cg.topics
+  end
+
+  def test_retrieve_and_commit_offsets
+    partition = Kazoo::Partition.new(@topic1, 0)
+
+    assert_nil @cg.retrieve_offset(partition)
+
+    @cg.commit_offset(partition, 1234)
+
+    assert_equal 1234 + 1, @cg.retrieve_offset(partition)
+
+    @cg.reset_all_offsets
+    assert_nil @cg.retrieve_offset(partition)
+  end
+
+  def test_retrieve_offsets_and_reset_all_offsets
+    partition10 = Kazoo::Partition.new(@topic1, 0)
+    partition40 = Kazoo::Partition.new(@topic4, 0)
+    partition41 = Kazoo::Partition.new(@topic4, 1)
+    partition42 = Kazoo::Partition.new(@topic4, 2)
+    partition43 = Kazoo::Partition.new(@topic4, 3)
+
+    assert @cg.retrieve_offsets(Kazoo::Subscription.everything).values.all? { |v| v.nil? }
+
+    @cg.commit_offset(partition10, 10)
+    @cg.commit_offset(partition40, 40)
+    @cg.commit_offset(partition41, 41)
+    @cg.commit_offset(partition42, 42)
+
+    offsets = @cg.retrieve_offsets(Kazoo::Subscription.everything)
+
+    assert_equal 5, offsets.length
+    assert_equal 11, offsets[partition10]
+    assert_equal 41, offsets[partition40]
+    assert_equal 42, offsets[partition41]
+    assert_equal 43, offsets[partition42]
+    assert_equal nil, offsets[partition43]
+
+    offsets = @cg.retrieve_offsets(['test.1'])
+
+    assert_equal 1, offsets.length
+    assert_equal 11, offsets[partition10]
+
+    @cg.reset_all_offsets
+    assert @cg.retrieve_offsets(Kazoo::Subscription.everything).values.all? { |v| v.nil? }
+  end
+
+  def test_retrieve_all_offsets_and_cleanup_offsets
+    deleted_topic = @cluster.topic('non_existing')
+    deleted_topic.destroy if deleted_topic.exists?
+    deleted_topic = @cluster.create_topic('non_existing', partitions: 1, replication_factor: 1)
+
+    subscription = Kazoo::Subscription.create([@topic4, deleted_topic])
+
+    @cg.commit_offset(@topic4.partition(0), 1234)
+    @cg.commit_offset(deleted_topic.partition(0), 1234)
+
+    deleted_topic.destroy
+
+    expected_offsets = {
+      deleted_topic.partition(0) => 1234 + 1,
+      @topic4.partition(0) => 1234 + 1,
+    }
+    assert_equal expected_offsets, @cg.retrieve_all_offsets
+
+    @cg.cleanup_offsets(Kazoo::Subscription.everything)
+
+    expected_offsets = {
+      @topic4.partition(0) => 1234 + 1,
+    }
+    assert_equal expected_offsets, @cg.retrieve_all_offsets
+
+    @cg.cleanup_offsets([])
+    assert_equal Hash.new, @cg.retrieve_all_offsets
   end
 end

--- a/test/functional/functional_subscription_test.rb
+++ b/test/functional/functional_subscription_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class FunctionalTopicManagementTest < Minitest::Test
+  def setup
+    zookeeper = ENV["ZOOKEEPER_PEERS"] || "127.0.0.1:2181"
+    @cluster = Kazoo.connect(zookeeper)
+  end
+
+  def test_consumergroup_subscription
+    cg = @cluster.consumergroup('test.consumergroup.subscription')
+    cg.create
+
+    assert_raises(Kazoo::NoRunningInstances) { cg.subscription }
+
+    subscription_1  = Kazoo::Subscription.create('topic.1')
+    subscription_14 = Kazoo::Subscription.create(['topic.1', 'topic.4'])
+
+    instance1 = cg.instantiate(subscription: subscription_1).register
+    instance2 = cg.instantiate(subscription: subscription_1).register
+    instance3 = cg.instantiate(subscription: subscription_14).register
+
+    assert_raises(Kazoo::InconsistentSubscriptions) { cg.subscription }
+
+    instance3.deregister
+
+    assert_equal subscription_1, cg.subscription
+    assert_equal subscription_1, instance1.subscription
+
+    instance2.deregister
+
+    assert_equal subscription_1, cg.subscription
+    assert_equal subscription_1, instance1.subscription
+
+    instance1.deregister
+
+    assert_raises(Kazoo::NoRunningInstances) { cg.subscription }
+  ensure
+    cg.destroy if cg.exists?
+  end
+end

--- a/test/functional/functional_topic_management_test.rb
+++ b/test/functional/functional_topic_management_test.rb
@@ -4,6 +4,12 @@ class FunctionalTopicManagementTest < Minitest::Test
   def setup
     zookeeper = ENV["ZOOKEEPER_PEERS"] || "127.0.0.1:2181"
     @cluster = Kazoo.connect(zookeeper)
+
+    topic = @cluster.topic('test.kazoo')
+    topic.destroy if topic.exists?
+
+    topic = @cluster.topic('test.kazoo.config')
+    topic.destroy if topic.exists?
   end
 
   def test_create_and_delete_topic

--- a/test/subscription_test.rb
+++ b/test/subscription_test.rb
@@ -1,0 +1,134 @@
+require 'test_helper'
+
+class SubscriptionTest < Minitest::Test
+  include MockCluster
+
+  def setup
+    @cluster = mock_cluster
+  end
+
+  def test_static_subscription_topics
+    subscription = Kazoo::Subscription.create(['test.1', 'nonexisting'])
+    topics = subscription.topics(@cluster)
+    assert_equal Set['test.1'], Set.new(topics.map(&:name))
+  end
+
+  def test_pattern_subscription_topics
+    subscription = Kazoo::Subscription.create(/^test\.\d+/, pattern: :white_list)
+    topics = subscription.topics(@cluster)
+    assert_equal Set['test.1', 'test.4'], Set.new(topics.map(&:name))
+
+    subscription = Kazoo::Subscription.create(/\.4/, pattern: :black_list)
+    topics = subscription.topics(@cluster)
+    assert_equal Set['test.1'], Set.new(topics.map(&:name))
+  end
+
+  def test_equality
+    subscription1 = Kazoo::Subscription.create(/^test\.\d+/, pattern: :white_list)
+    subscription2 = Kazoo::Subscription.create(/^test\.\d+/, pattern: :white_list)
+    subscription3 = Kazoo::Subscription.create(/^test\.\d+/, pattern: :black_list)
+    subscription4 = Kazoo::Subscription.create(/^test\.\d*/, pattern: :white_list)
+    assert subscription1 == subscription2
+    refute subscription1 == subscription3
+    refute subscription1 == subscription4
+
+    subscription1 = Kazoo::Subscription.create(:'test.1')
+    subscription2 = Kazoo::Subscription.create(['test.1'])
+    subscription3 = Kazoo::Subscription.create(['test.1', 'test.4'])
+    assert subscription1 == subscription2
+    refute subscription1 == subscription3
+  end
+
+  def test_subscription_from_json
+    timestamp_msec = 628232400123
+    timestamp = Time.at(BigDecimal.new(timestamp_msec) / BigDecimal.new(1000))
+
+    json_payload = JSON.generate(
+      version:      1,
+      timestamp:    timestamp_msec,
+      pattern:      "static",
+      subscription: { 'topic.1' => 1, 'topic.4' => 1 },
+    )
+
+    subscription = Kazoo::Subscription.from_json(json_payload)
+    assert_kind_of Kazoo::StaticSubscription, subscription
+    assert_equal timestamp, subscription.timestamp
+    assert_equal 1, subscription.version
+    assert_equal Set['topic.1', 'topic.4'], Set.new(subscription.topic_names)
+
+    json_payload = JSON.generate(
+      version:      1,
+      timestamp:    timestamp_msec,
+      pattern:      "black_list",
+      subscription: { "^test\\.\\d+" => 1 },
+    )
+
+    subscription = Kazoo::Subscription.from_json(json_payload)
+    assert_kind_of Kazoo::PatternSubscription, subscription
+    assert_equal timestamp, subscription.timestamp
+    assert_equal 1, subscription.version
+    assert subscription.black_list?
+    assert_equal %r{^test\.\d+}, subscription.regexp
+  end
+
+  def test_single_topic_static_subscription_json
+    subscription = Kazoo::Subscription.create('topic')
+    json = subscription.to_json
+
+    parsed_subscription = JSON.parse(json)
+    assert_equal 1, parsed_subscription.fetch('version')
+    assert_equal 'static', parsed_subscription.fetch('pattern')
+    assert_kind_of Integer, parsed_subscription.fetch('timestamp')
+
+    assert_kind_of Hash, parsed_subscription.fetch('subscription')
+    assert_equal 1, parsed_subscription.fetch('subscription').length
+    assert_equal 1, parsed_subscription.fetch('subscription').fetch('topic')
+  end
+
+  def test_multi_topic_static_subscription_json
+    subscription = Kazoo::Subscription.create([:topic1, :topic2])
+    json = subscription.to_json
+
+    parsed_subscription = JSON.parse(json)
+    assert_equal 1, parsed_subscription.fetch('version')
+    assert_equal 'static', parsed_subscription.fetch('pattern')
+    assert_kind_of Integer, parsed_subscription.fetch('timestamp')
+
+    assert_kind_of Hash, parsed_subscription.fetch('subscription')
+    assert_equal 2, parsed_subscription.fetch('subscription').length
+    assert_equal 1, parsed_subscription.fetch('subscription').fetch('topic1')
+    assert_equal 1, parsed_subscription.fetch('subscription').fetch('topic2')
+  end
+
+  def test_whitelist_subscription_json
+    subscription = Kazoo::Subscription.create(/^topic/)
+    json = subscription.to_json
+
+    parsed_subscription = JSON.parse(json)
+    assert_equal 1, parsed_subscription.fetch('version')
+    assert_equal 'white_list', parsed_subscription.fetch('pattern')
+    assert_kind_of Integer, parsed_subscription.fetch('timestamp')
+
+    assert_kind_of Hash, parsed_subscription.fetch('subscription')
+    assert_equal 1, parsed_subscription.fetch('subscription').length
+
+    assert_equal ["^topic"], parsed_subscription.fetch('subscription').keys
+    assert_equal [1], parsed_subscription.fetch('subscription').values
+  end
+
+  def test_blacklist_subscription_json
+    subscription = Kazoo::Subscription.create(/^topic/, pattern: :black_list)
+    json = subscription.to_json
+
+    parsed_subscription = JSON.parse(json)
+    assert_equal 1, parsed_subscription.fetch('version')
+    assert_equal 'black_list', parsed_subscription.fetch('pattern')
+    assert_kind_of Integer, parsed_subscription.fetch('timestamp')
+
+    assert_kind_of Hash, parsed_subscription.fetch('subscription')
+    assert_equal 1, parsed_subscription.fetch('subscription').length
+
+    assert_equal ["^topic"], parsed_subscription.fetch('subscription').keys
+    assert_equal [1], parsed_subscription.fetch('subscription').values
+  end
+end


### PR DESCRIPTION
This adds the "subscription" concept to this library. A subscription describes what topics a client (usually a consumer) is interested in. We can use this concept for several different things:

- Figure out what topics a consumer is interested in right now. Right now, we have to do this based on what topics have been claimed by a consumer at some point, but this causes issues when a consumer no longer is interested in a topic, or when a topic is deleted. This is currently causing issues for our monitoring.
- Double check that all the instances of a consumer are using the same subscription, and make sure all the partitions of a subscription are actually consumed by exactly one instance of a consumer. These are requirements for a consumer group to function properly, and we can now monitor those.
- React to changes in a subscription, e.g. partitions being added, or for a subscription based on a regular expression: topics being added. E.g., a consumer will automatically start consuming new partitions as they are added. (This part is still missing, see `watch_partitions`, and will require changes in the consumer library).
- Clean up unused zookeeper nodes that store claims or offsets for topics that we are no longer subscribed to.

We have 3 kinds of subscriptions:
- **StaticSubscription** for a static list of topics (which is what we are always using right now).
- **PatternSubscription** with `pattern=white_list`: topic whitelist based on a regular expression
- **PatternSubscription** with `pattern=black_list`: topic blacklist using regexp.

This follows the way subscription information is stored in Zookeeper by the high level JVM consumer. Every consumer instance stores its subscription as data for its ephemeral node on `/consumers/ids/<id>`. I have implemented setting this value based on a `Subscription` instance, and instantiating a `Subscription` instance based on the data in Zookeeper. I also added some function to clean up claim and offset nodes based on a subscription object, e.g. it will remove all nodes that are not covered by the provided subscription.

One caveat of the approach if storing the subscription with every instance, is that we cannot deduct the subscription of the consumer group if it has zero running instances. In this case, I raise a `Kazoo::NoRunningInstances` exception

@andremedeiros @honkfestival @kvs