### PR TITLE
Continue if node exists during recursive create

### DIFF
--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -125,8 +125,8 @@ module Kazoo
 
     protected
 
-    # Recursively creates a node in Zookeeper, by recusrively trying to create its
-    # parent if it doesn not yet exist.
+    # Recursively creates a node in Zookeeper, by recursively trying to create its
+    # parent if it does not yet exist.
     def recursive_create(path: nil)
       raise ArgumentError, "path is a required argument" if path.nil?
 
@@ -137,7 +137,10 @@ module Kazoo
       when Zookeeper::Constants::ZNONODE
         recursive_create(path: File.dirname(path))
         result = zk.create(path: path)
-        raise Kazoo::Error, "Failed to create node #{path}. Result code: #{result.fetch(:rc)}" unless result.fetch(:rc) == Zookeeper::Constants::ZOK
+        rc = result.fetch(:rc)
+        if rc != Zookeeper::Constants::ZOK && rc != Zookeeper::Constants::ZNODEEXISTS
+          raise Kazoo::Error, "Failed to create node #{path}. Result code: #{rc}"
+        end
       else
         raise Kazoo::Error, "Failed to create node #{path}. Result code: #{result.fetch(:rc)}"
       end

--- a/test/functional/functional_consumergroup_test.rb
+++ b/test/functional/functional_consumergroup_test.rb
@@ -111,6 +111,20 @@ class FunctionalConsumergroupTest < Minitest::Test
     assert_nil @cg.retrieve_offset(partition)
   end
 
+  def test_commit_offset_race_condition
+    partitions = [
+      Kazoo::Partition.new(@topic1, 0),
+      Kazoo::Partition.new(@topic4, 0),
+      Kazoo::Partition.new(@topic4, 1),
+      Kazoo::Partition.new(@topic4, 2),
+      Kazoo::Partition.new(@topic4, 3)
+    ]
+
+    partitions.map do |partition|
+      Thread.new { @cg.commit_offset(partition, 10) }
+    end.map(&:join)
+  end
+
   def test_retrieve_offsets_and_reset_all_offsets
     partition10 = Kazoo::Partition.new(@topic1, 0)
     partition40 = Kazoo::Partition.new(@topic4, 0)


### PR DESCRIPTION
This fixes a race condition when multiple threads / processes are creating nodes for the first time.  This may not the best way of handling this but it seems to do the job.

Edit: The test consistently fails while running a 3-member ZK + Kafka cluster locally.