### PR TITLE
Add preferred leadership election.

### DIFF
--- a/lib/kazoo/cli/cluster.rb
+++ b/lib/kazoo/cli/cluster.rb
@@ -23,6 +23,13 @@ module Kazoo
           $stdout.puts "Broker #{broker_name} is non-critical and can be stopped safely."
         end
       end
+
+      desc "election", "Triggers a preferred leader election"
+      def election
+        validate_class_options!
+
+        kafka_cluster.preferred_leader_election
+      end
     end
   end
 end

--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -81,6 +81,10 @@ module Kazoo
       end
     end
 
+    def to_json(generator)
+      generator.generate(topic: topic.name, partition: id)
+    end
+
     protected
 
     def refresh_state

--- a/test/cluster_test.rb
+++ b/test/cluster_test.rb
@@ -13,4 +13,30 @@ class ClusterTest < Minitest::Test
     @cluster.topics['test.4'].partitions[2].expects(:isr).returns([@cluster.brokers[1]])
     assert @cluster.under_replicated?
   end
+
+  def test_preferred_leader_election
+    @cluster.zk.stubs(:create).with do |parameters|
+      payload = JSON.parse(parameters.fetch(:data))
+
+      [
+        parameters.fetch(:path) == "/admin/preferred_replica_election",
+        payload.fetch('version') == 1,
+        payload.fetch('partitions').length == 1,
+        payload.fetch('partitions').first.fetch('topic') == 'test.1',
+        payload.fetch('partitions').first.fetch('partition') == 0,
+      ].all?
+    end.returns(rc: Zookeeper::Constants::ZOK)
+
+    assert @cluster.preferred_leader_election(partitions: [@cluster.topic('test.1').partition(0)])
+  end
+
+
+  def test_preferred_leader_election_in_progress
+    @cluster.zk.stubs(:create).returns(rc: Zookeeper::Constants::ZNODEEXISTS)
+    exception = assert_raises(Kazoo::Error) do
+      @cluster.preferred_leader_election
+    end
+
+    assert_equal "Another preferred leader election is still in progress", exception.message
+  end
 end


### PR DESCRIPTION
Pretty sure I reversed engineered this properly from https://apache.googlesource.com/kafka/+/0.8.2/core/src/main/scala/kafka/admin/PreferredReplicaLeaderElectionCommand.scala

Questions:
- should we wait for the election to complete before returning (by watching the zookeeper node)?
- can we return a useful value?

@kvs @mkobetic