### PR TITLE
Kafka 0.9 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ confluent/stop: confluent/rest/stop confluent/registry/stop confluent/kafka/stop
 # Download & extract tasks
 
 confluent/confluent.tgz:
-	mkdir -p confluent && wget http://packages.confluent.io/archive/1.0/confluent-1.0-2.10.4.tar.gz -O confluent/confluent.tgz
+	mkdir -p confluent && wget http://packages.confluent.io/archive/2.0/confluent-2.0.1-2.11.7.tar.gz -O confluent/confluent.tgz
 
 confluent/EXTRACTED: confluent/confluent.tgz
 	tar xzf confluent/confluent.tgz -C confluent --strip-components 1 && mkdir confluent/logs && touch confluent/EXTRACTED

--- a/lib/kazoo/broker.rb
+++ b/lib/kazoo/broker.rb
@@ -79,9 +79,14 @@ module Kazoo
 
     # Instantiates a Kazoo::Broker instance based on the Broker metadata that is stored
     # in Zookeeper under `/brokers/<id>`.
+    # TODO: add support for endpoints in Kafka 0.9
     def self.from_json(cluster, id, json)
-      raise Kazoo::VersionNotSupported unless json.fetch('version') == 1
-      new(cluster, id.to_i, json.fetch('host'), json.fetch('port'), jmx_port: json.fetch('jmx_port', nil))
+      case json.fetch('version')
+      when 1, 2
+        new(cluster, id.to_i, json.fetch('host'), json.fetch('port'), jmx_port: json.fetch('jmx_port', nil))
+      else
+        raise Kazoo::VersionNotSupported
+      end
     end
   end
 end


### PR DESCRIPTION
Broker metadata in Zookeeper was bumped to version 2 to support plaintext and encrypted endpoints. I am ignoring encrypted endpoints for now; simply allowing version 2 will make it work again.