### PR TITLE
Fixed issue #27 undefined local variable or method 'result' in instances_with_subscription

### DIFF
--- a/lib/kazoo/consumergroup.rb
+++ b/lib/kazoo/consumergroup.rb
@@ -318,7 +318,7 @@ module Kazoo
           Thread.abort_on_exception = true
 
           subscription_result = cluster.zk.get(path: "/consumers/#{name}/ids/#{id}")
-          raise Kazoo::Error, "Failed to retrieve subscription for instance. Error code: #{result.fetch(:rc)}" if subscription_result.fetch(:rc) != Zookeeper::Constants::ZOK
+          raise Kazoo::Error, "Failed to retrieve subscription for instance. Error code: #{subscription_result.fetch(:rc)}" if subscription_result.fetch(:rc) != Zookeeper::Constants::ZOK
           subscription = Kazoo::Subscription.from_json(subscription_result.fetch(:data))
           mutex.synchronize { instances << Instance.new(self, id: id, subscription: subscription) }
         end

--- a/lib/kazoo/version.rb
+++ b/lib/kazoo/version.rb
@@ -1,3 +1,3 @@
 module Kazoo
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end


### PR DESCRIPTION
In case of error when connecting to zookeeper to query consumer instances with specific ids, the error message references an undeclared var name `result`, changed to `subscription_result`

@wvanbergen 