### PR TITLE
Removes caching of ISR state

### DIFF
--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -21,14 +21,14 @@ module Kazoo
 
     def leader
       @mutex.synchronize do
-        refresh_state if @leader.nil?
+        refresh_state
         @leader
       end
     end
 
     def isr
       @mutex.synchronize do
-        refresh_state if @isr.nil?
+        refresh_state
         @isr
       end
     end

--- a/test/partition_test.rb
+++ b/test/partition_test.rb
@@ -18,6 +18,7 @@ class PartitionTest < Minitest::Test
 
     json_payload = '{"controller_epoch":157,"leader":1,"version":1,"leader_epoch":8,"isr":[3,2,1]}'
     @cluster.zk.expects(:get).with(path: "/brokers/topics/test.1/partitions/0/state").returns(data: json_payload, rc: 0)
+    @cluster.zk.expects(:get).with(path: "/brokers/topics/test.1/partitions/0/state").returns(data: json_payload, rc: 0)
 
     assert_equal 1, partition.leader.id
     assert_equal [3,2,1], partition.isr.map(&:id)


### PR DESCRIPTION
Whenever we call under_replicated? we want it to be the current,
non-cached data.  This removes caching of the ISR state and fetches it
from Zookeeper every time.

r: @wvanbergen 
c: @sam-obeid 