### PR TITLE
Pick the first broker that's not down as preferred

### DIFF
--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -16,7 +16,7 @@ module Kazoo
     end
 
     def preferred_leader
-      @replicas.first
+      @replicas.compact.first
     end
 
     def leader


### PR DESCRIPTION
If a broker was down, but a partition had it at the head of its replica list, preferred_leader was `nil`, even when other replicas were up.