### PR TITLE
Avoids crashes when broker is down and in ISR list

### DIFF
--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -99,7 +99,13 @@ module Kazoo
       raise Kazoo::VersionNotSupported unless json.fetch('version') == 1
 
       @leader = cluster.brokers.fetch(json.fetch('leader'))
-      @isr = json.fetch('isr').map { |r| cluster.brokers.fetch(r) }
+      @isr = json.fetch('isr').map do |r|
+        begin
+          cluster.brokers.fetch(r)
+        rescue KeyError
+          raise Kazoo::Error, "Broker #{r} not in cluster but in ISR list #{json.fetch('isr').inspect}?!"
+        end
+      end
     end
   end
 end

--- a/test/partition_test.rb
+++ b/test/partition_test.rb
@@ -44,4 +44,15 @@ class PartitionTest < Minitest::Test
     refute partition.valid?
     assert_raises(Kazoo::ValidationError) { partition.validate }
   end
+
+  def test_raises_unknown_broker
+    partition = @cluster.topics['test.1'].partitions[0]
+    partition.unstub(:leader)
+    partition.unstub(:isr)
+
+    json_payload = '{"controller_epoch":157,"leader":1,"version":1,"leader_epoch":8,"isr":[4,2,1]}'
+    @cluster.zk.expects(:get).with(path: "/brokers/topics/test.1/partitions/0/state").returns(data: json_payload, rc: 0)
+
+    assert_raises(Kazoo::Error) { partition.under_replicated? }
+  end
 end


### PR DESCRIPTION
In certain conditions, a partition ISR list includes a broker that Kazoo
does not currently have information about.  While this is rare, it is
exacerbated by restarting brokers and triggering topology changes.
There are also likely other (better) solutions to this; however this fix
is most expedient.