### PR TITLE
Use zookeeper watchers to keep brokers list in sync

### DIFF
--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -18,7 +18,7 @@ module Kazoo
 
       @root = '/brokers/ids'
       children = zk.get_children(path: @root, watcher: children_watch)
-      children.fetch(:children).each do |child|
+      children.fetch(:children).map(&:to_i).each do |child|
         data = zk.get(path: "#{@root}/#{child}", watcher: data_watch(child))
         @brokers[child] = Kazoo::Broker.from_json(self, child, JSON.parse(data.fetch(:data)))
       end
@@ -187,7 +187,7 @@ module Kazoo
         end
 
         added_children = new_children.fetch(:children) - @brokers.keys
-        added_children.each do |child|
+        added_children.map(&:to_i).each do |child|
           data = zk.get(path: "#{@root}/#{child}", watcher: data_watch(child))
           @brokers[child] = Kazoo::Broker.from_json(self, child, JSON.parse(data.fetch(:data)))
         end

--- a/lib/kazoo/cluster.rb
+++ b/lib/kazoo/cluster.rb
@@ -17,11 +17,7 @@ module Kazoo
       # TODO: Handle case where /brokers/ids does not exist
 
       @root = '/brokers/ids'
-      children = zk.get_children(path: @root, watcher: children_watch)
-      children.fetch(:children).map(&:to_i).each do |child|
-        data = zk.get(path: "#{@root}/#{child}", watcher: data_watch(child))
-        @brokers[child] = Kazoo::Broker.from_json(self, child, JSON.parse(data.fetch(:data)))
-      end
+      children_watch.call(path: @root)
     end
 
     # TODO: Handle chroots?


### PR DESCRIPTION
@psycotica0-shopify and I put this together.  We're moving to using zookeeper watches to keep the set of brokers in sync, instead of forcing the caller to reset metadata and keeping our own cache.

Related to https://github.com/wvanbergen/kazoo/pull/35#issuecomment-277260237