### PR TITLE
Add version 4 and bump for release

### DIFF
--- a/lib/kazoo/broker.rb
+++ b/lib/kazoo/broker.rb
@@ -82,7 +82,7 @@ module Kazoo
     # TODO: add support for endpoints in Kafka 0.9+
     def self.from_json(cluster, id, json)
       case json.fetch('version')
-      when 1, 2, 3
+      when 1, 2, 3, 4
         new(cluster, id.to_i, json.fetch('host'), json.fetch('port'), jmx_port: json.fetch('jmx_port', nil))
       else
         raise Kazoo::VersionNotSupported

--- a/lib/kazoo/version.rb
+++ b/lib/kazoo/version.rb
@@ -1,3 +1,3 @@
 module Kazoo
-  VERSION = "0.5.5"
+  VERSION = "0.5.6"
 end


### PR DESCRIPTION
@wvanbergen it looks like we now have `version: 4` in the zookeeper tree for some brokers.  Longer-term we should find a way to work around this, but I'm currently blocked so just made this small fix.