### PR TITLE
Raises exception when unknown leader for partition

### DIFF
--- a/lib/kazoo/partition.rb
+++ b/lib/kazoo/partition.rb
@@ -98,7 +98,12 @@ module Kazoo
       json = JSON.parse(json_payload)
       raise Kazoo::VersionNotSupported unless json.fetch('version') == 1
 
-      @leader = cluster.brokers.fetch(json.fetch('leader'))
+      begin
+        @leader = cluster.brokers.fetch(json.fetch('leader'))
+      rescue KeyError
+        raise Kazoo::Error, "Topic #{topic.name}:#{id} has unknown leader! Brokers: '#{cluster.brokers.keys.join(',')}'; 'Payload: '#{json_payload.inspect}'"
+      end
+
       @isr = json.fetch('isr').map do |r|
         begin
           cluster.brokers.fetch(r)

--- a/lib/kazoo/version.rb
+++ b/lib/kazoo/version.rb
@@ -1,3 +1,3 @@
 module Kazoo
-  VERSION = "0.5.6"
+  VERSION = "0.5.7"
 end

--- a/test/partition_test.rb
+++ b/test/partition_test.rb
@@ -55,4 +55,15 @@ class PartitionTest < Minitest::Test
 
     assert_raises(Kazoo::Error) { partition.under_replicated? }
   end
+
+  def test_raises_unknown_leader
+    partition = @cluster.topics['test.1'].partitions[0]
+    partition.unstub(:leader)
+    partition.unstub(:isr)
+
+    json_payload = '{"controller_epoch":90,"leader":-1,"version":1,"leader_epoch":135,"isr":[2,1,0]}'
+    @cluster.zk.expects(:get).with(path: "/brokers/topics/test.1/partitions/0/state").returns(data: json_payload, rc: 0)
+
+    assert_raises(Kazoo::Error) { partition.under_replicated? }
+  end
 end


### PR DESCRIPTION
We are getting exceptions in our production environment, where `-1` is set for the leader.  This PR raises a Kazoo exception when this happens, instead of `KeyError` to the caller.

```
Readiness probe failed: /var/lib/gems/2.3.0/gems/kazoo-ruby-0.5.6/lib/kazoo/partition.rb:101:in `fetch': key not found: -1 (KeyError)
           from /var/lib/gems/2.3.0/gems/kazoo-ruby-0.5.6/lib/kazoo/partition.rb:101:in `set_state_from_json'
           from /var/lib/gems/2.3.0/gems/kazoo-ruby-0.5.6/lib/kazoo/partition.rb:94:in `refresh_state'
           from /var/lib/gems/2.3.0/gems/kazoo-ruby-0.5.6/lib/kazoo/partition.rb:31:in `block in isr'
           from /var/lib/gems/2.3.0/gems/kazoo-ruby-0.5.6/lib/kazoo/partition.rb:30:in `synchronize'
           from /var/lib/gems/2.3.0/gems/kazoo-ruby-0.5.6/lib/kazoo/partition.rb:30:in `isr'
           from /healthcheck.rb:21:in `block in <main>'
           from /healthcheck.rb:21:in `count'
           from /healthcheck.rb:21:in `<main>'
```